### PR TITLE
Fix pandas warnings

### DIFF
--- a/qpbenchmark/report.py
+++ b/qpbenchmark/report.py
@@ -103,12 +103,17 @@ class Report:
                     for name in names
                 }
             )
-            df = pandas.concat(
-                [
-                    df,
-                    pandas.DataFrame(row),
-                ],
-                ignore_index=True,
+            row_df = pandas.DataFrame(row)
+            df = (
+                row_df
+                if df.empty
+                else pandas.concat(
+                    [
+                        df,
+                        row_df,
+                    ],
+                    ignore_index=True,
+                )
             )
         df = df.sort_values(by="tolerance")
         return df.to_markdown(index=False)
@@ -146,12 +151,17 @@ class Report:
                     for name in names
                 }
             )
-            df = pandas.concat(
-                [
-                    df,
-                    pandas.DataFrame(row),
-                ],
-                ignore_index=True,
+            row_df = pandas.DataFrame(row)
+            df = (
+                row_df
+                if df.empty
+                else pandas.concat(
+                    [
+                        df,
+                        row_df,
+                    ],
+                    ignore_index=True,
+                )
             )
         df = df.sort_values(by=["solver", "parameter"])
         return df.to_markdown(index=False)


### PR DESCRIPTION
The two warnings were:

```
qpbenchmark/report.py:108: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  df = pandas.concat(
```

And:

```
qpbenchmark/lib/python3.10/site-packages/qpbenchmark/report.py:151: FutureWarning: The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation.
  df = pandas.concat(
```