### PR TITLE
Add tolerance to is_posdef.

### DIFF
--- a/qpbenchmark/utils.py
+++ b/qpbenchmark/utils.py
@@ -165,10 +165,11 @@ def time_solve_problem(
     return solution, runtime
 
 
-def is_posdef(M: np.ndarray) -> bool:
+def is_posdef(M: np.ndarray, tol: float = 1e-14) -> bool:
     """Test whether a matrix is positive-definite.
 
     Args:
         M: Matrix to test.
+        tol: Threshold for when eigenvalues are considered nonzero
     """
-    return all(np.linalg.eigvals(M) > 0)
+    return all(np.linalg.eigvals(M) > tol)


### PR DESCRIPTION
This PR adds a tolerance to the positive-definite check in `is_posdef ` to filter out QPs which have Hessians that are numerically singular.
For example, the problem "TAME" in the MM testset is classified as positive definite, but it has the Hessian

$$
P = \begin{bmatrix}
2 & -2 \\
-2 & 2
\end{bmatrix},
$$

which is clearly singular. Numerically the singular eigenvalue evaluates to ~`1e-16`, and since `is_posdef` currently simply compares `>0`, the problem is classified as posef.